### PR TITLE
Enable chmod of backup files

### DIFF
--- a/ghettoVCB.sh
+++ b/ghettoVCB.sh
@@ -317,6 +317,7 @@ endTimer() {
 captureDefaultConfigurations() {
     DEFAULT_VM_BACKUP_VOLUME="${VM_BACKUP_VOLUME}"
     DEFAULT_DISK_BACKUP_FORMAT="${DISK_BACKUP_FORMAT}"
+    DEFAULT_BACKUP_FILES_CHMOD="${BACKUP_FILES_CHMOD}"
     DEFAULT_VM_BACKUP_ROTATION_COUNT="${VM_BACKUP_ROTATION_COUNT}"
     DEFAULT_POWER_VM_DOWN_BEFORE_BACKUP="${POWER_VM_DOWN_BEFORE_BACKUP}"
     DEFAULT_ENABLE_HARD_POWER_OFF="${ENABLE_HARD_POWER_OFF}"
@@ -338,6 +339,7 @@ captureDefaultConfigurations() {
 useDefaultConfigurations() {
     VM_BACKUP_VOLUME="${DEFAULT_VM_BACKUP_VOLUME}"
     DISK_BACKUP_FORMAT="${DEFAULT_DISK_BACKUP_FORMAT}"
+    BACKUP_FILES_CHMOD="${BACKUP_FILES_CHMOD}"
     VM_BACKUP_ROTATION_COUNT="${DEFAULT_VM_BACKUP_ROTATION_COUNT}"
     POWER_VM_DOWN_BEFORE_BACKUP="${DEFAULT_POWER_VM_DOWN_BEFORE_BACKUP}"
     ENABLE_HARD_POWER_OFF="${DEFAULT_ENABLE_HARD_POWER_OFF}"
@@ -489,6 +491,7 @@ dumpVMConfigurations() {
     logger "info" "CONFIG - VM_BACKUP_ROTATION_COUNT = ${VM_BACKUP_ROTATION_COUNT}"
     logger "info" "CONFIG - VM_BACKUP_DIR_NAMING_CONVENTION = ${VM_BACKUP_DIR_NAMING_CONVENTION}"
     logger "info" "CONFIG - DISK_BACKUP_FORMAT = ${DISK_BACKUP_FORMAT}"
+    logger "info" "CONFIG - BACKUP_FILES_CHMOD = ${BACKUP_FILES_CHMOD}"
     logger "info" "CONFIG - POWER_VM_DOWN_BEFORE_BACKUP = ${POWER_VM_DOWN_BEFORE_BACKUP}"
     logger "info" "CONFIG - ENABLE_HARD_POWER_OFF = ${ENABLE_HARD_POWER_OFF}"
     logger "info" "CONFIG - ITER_TO_WAIT_SHUTDOWN = ${ITER_TO_WAIT_SHUTDOWN}"
@@ -1190,6 +1193,11 @@ ghettoVCB() {
                         logger "info" "Creating symlink \"${SYMLINK_SRC}\" to \"${SYMLINK_DST1}\""
                         rm -f "${SYMLINK_SRC}"
                         ln -sf "${SYMLINK_DST1}" "${SYMLINK_SRC}"
+                    fi
+
+                    if [[ "${BACKUP_FILES_CHMOD}" != "" ]]
+                    then
+                        chmod -R "${BACKUP_FILES_CHMOD}" "${VM_BACKUP_DIR}"
                     fi
 
                     #storage info after backup


### PR DESCRIPTION
Enable a chmod to be run on the backup files. This enables easier rsync from backup destination