### PR TITLE
Fix for -symlink creation

### DIFF
--- a/ghettoVCB.sh
+++ b/ghettoVCB.sh
@@ -1184,10 +1184,11 @@ ghettoVCB() {
                         if [[ ${ENABLE_COMPRESSION} -eq 1 ]]; then
                             SYMLINK_DST1="${RSYNC_LINK_DIR}.gz"
                         else
-                            SYMLINK_DST1=${RSYNC_LINK_DIR}
+                            SYMLINK_DST1="${RSYNC_LINK_DIR}"
                         fi
-                        SYMLINK_SRC="$(echo "${SYMLINK_DST%*-*-*-*_*-*-*}")-symlink"
+                        SYMLINK_SRC="${BACKUP_DIR}/${VM_NAME}-symlink"
                         logger "info" "Creating symlink \"${SYMLINK_SRC}\" to \"${SYMLINK_DST1}\""
+                        rm -f "${SYMLINK_SRC}"
                         ln -sf "${SYMLINK_DST1}" "${SYMLINK_SRC}"
                     fi
 
@@ -1205,10 +1206,11 @@ ghettoVCB() {
                         if [[ ${ENABLE_COMPRESSION} -eq 1 ]] ; then
                             SYMLINK_DST1="${RSYNC_LINK_DIR}.gz"
                         else
-                            SYMLINK_DST1=${RSYNC_LINK_DIR}
+                            SYMLINK_DST1="${RSYNC_LINK_DIR}"
                         fi
-                        SYMLINK_SRC="$(echo "${SYMLINK_DST%*-*-*-*_*-*-*}")-symlink"
+                        SYMLINK_SRC="${BACKUP_DIR}/${VM_NAME}-symlink"
                         logger "info" "Creating symlink \"${SYMLINK_SRC}\" to \"${SYMLINK_DST1}\""
+                        rm -f "${SYMLINK_SRC}"
                         ln -sf "${SYMLINK_DST1}" "${SYMLINK_SRC}"
                     fi
 


### PR DESCRIPTION
Remove an existing -symlink entry prior to creating a new one. This is to ensure that the new -symlink entry is not created as a link within the directory pointed to by the existing symbolic link. This behaviour is observed when writing backups to a Linux hosted NFS share.
